### PR TITLE
Add :partial_roles and wrap EC2 calls with retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ regions.each do |region|
 end
 ```
 
+If you want to specify roles for a subset of instances in the autoscaling group, you can use
+`:partial_roles`.  These will be spread out 1 per server:
+ ```ruby
+autoscale 'asg-app', user: 'apps', roles: [:app, :web],
+  partial_roles: [
+    { name: :migrate, instances: 1 },
+    { name: :sidekiq, instances: 2 }
+  ]
+```
+
 The name of the newly created launch configurations are available via `fetch(:asg_launch_config)`.
 This is a two-dimensional hash with region and autoscaling group name as keys.
 You can output these or store them as necessary in an `after 'deploy:finished'` hook.

--- a/capistrano-asg.gemspec
+++ b/capistrano-asg.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-autoscaling', '~> 1'
   spec.add_dependency 'capistrano', '> 3.0.0'
   spec.add_dependency 'activesupport', '>= 4.0.0'
+  spec.add_dependency 'duplicate', '~> 1'
 end

--- a/capistrano-asg.gemspec
+++ b/capistrano-asg.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-autoscaling', '~> 1'
   spec.add_dependency 'capistrano', '> 3.0.0'
   spec.add_dependency 'activesupport', '>= 4.0.0'
-  spec.add_dependency 'duplicate', '~> 1'
 end

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -24,10 +24,11 @@ require 'capistrano/dsl'
 
 load File.expand_path('../asg/tasks/asg.rake', __FILE__)
 
-def autoscale(groupname, *args)
+def autoscale(groupname, **args)
   include Capistrano::DSL
   include Capistrano::Asg::Aws::AutoScaling
   include Capistrano::Asg::Aws::EC2
+  include Capistrano::Asg::Retryable
 
   autoscaling_group = autoscaling_resource.group(groupname)
   asg_instances = autoscaling_group.instances
@@ -38,22 +39,43 @@ def autoscale(groupname, *args)
   (regions[region] ||= []) << groupname
   set :regions, regions
 
+  # Create an array of role names to be distributed across the ASG
+  partial_queue = []
+  if args.key?(:partial_roles)
+    args[:partial_roles].each do |partial|
+      instances = partial.key?(:instances) ? partial[:instances] : 1
+      instances.times { partial_queue << partial[:name].to_s }
+    end
+    args.delete(:partial_roles)
+  end
+
   asg_instances.each do |asg_instance|
     if asg_instance.health_status != 'Healthy'
       puts "Autoscaling: Skipping unhealthy instance #{asg_instance.id}"
     else
-      ec2_instance = ec2_resource.instance(asg_instance.id)
-      hostname = ec2_instance.private_ip_address
-      puts "Autoscaling: Adding server #{hostname}"
-      server(hostname, *args)
+      with_retry do
+        ec2_instance = ec2_resource.instance(asg_instance.id)
+        hostname = ec2_instance.private_ip_address
+        puts "Autoscaling: Adding server #{hostname}"
+        # create a complete temp copy of the array contents instead of just copying the references
+        host_args = Marshal.load(Marshal.dump(args))
+        if additional_role = partial_queue.shift
+          host_args[:roles] << additional_role
+        end
+        server(hostname, **host_args)
+      end
     end
   end
 
-  if asg_instances.count > 0 && fetch(:create_ami, true)
-    after('deploy:finishing', 'asg:scale')
-  else
-    puts 'Autoscaling: AMI could not be created because no running instances were found.\
-      Is your autoscale group name correct?'
+  puts "WARNING: Not all partial roles were assigned: #{partial_queue}" unless partial_queue.empty?
+
+  if fetch(:create_ami, true)
+    if asg_instances.count > 0
+      after('deploy:finishing', 'asg:scale')
+    else
+      puts 'Autoscaling: AMI could not be created because no running instances were found.\
+        Is your autoscale group name correct?'
+    end
   end
 
   reset_autoscaling_objects

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -58,7 +58,7 @@ def autoscale(groupname, roles: [], partial_roles: [], **args)
         if additional_role = partial_queue.shift
           host_roles << additional_role
         end
-        server(hostname, roles: roles, **args)
+        server(hostname, roles: host_roles, **args)
       end
     end
   end

--- a/lib/capistrano/asg/launch_configuration.rb
+++ b/lib/capistrano/asg/launch_configuration.rb
@@ -18,9 +18,9 @@ module Capistrano
 
       def save(ami)
         info "Creating an EC2 Launch Configuration for AMI: #{ami.aws_counterpart.id}"
-        ec2_instance = ec2_resource.instance(base_ec2_instance.id)
 
         with_retry do
+          ec2_instance = ec2_resource.instance(base_ec2_instance.id)
           @aws_counterpart = autoscaling_resource.create_launch_configuration(
             launch_configuration_name: name,
             image_id: ami.aws_counterpart.id,

--- a/lib/capistrano/asg/retryable.rb
+++ b/lib/capistrano/asg/retryable.rb
@@ -11,6 +11,8 @@ module Capistrano
           puts "Retrying in #{delay} seconds..."
           sleep delay
           retry
+        else
+          raise e.message
         end
       end
     end

--- a/lib/capistrano/asg/version.rb
+++ b/lib/capistrano/asg/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Asg
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/161725819

Wrap EC2 calls with retries in case we hit API rate limits.  Also includes :partial_roles to only run on a subset of instances in the ASG

Note that we've been using version 0.6.1 of capistrano-asg and this is based off 0.7.0 that uses the aws-sdk v3 (may require additional Gemfile updates in the apps)