### PR TITLE
query for ec2 resources in single query

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   ruby-latest:
     resource_class: small
     docker:
-      - image: circleci/ruby:latest
+      - image: circleci/ruby:2.6.2
         environment:
           BUNDLE_VERSION: "~> 1.17"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 0.11.0-pre
+
+* Query for all instance IP's with a single call and fail if no healthy instances
+
 ## 0.10.0
 
 * Raise error if autoscaling group has no healthy instances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## 0.11.0-pre
+## 0.11.0
 
 * Query for all instance IP's with a single call and fail if no healthy instances
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## 0.11.0
+## 0.11.0-pre
 
 * Query for all instance IP's with a single call and fail if no healthy instances
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    capistrano-asg (0.10.0)
+    capistrano-asg (0.11.0.pre.pre)
       activesupport (~> 5.2)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-ec2 (~> 1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    capistrano-asg (0.11.0)
+    capistrano-asg (0.11.0-pre)
       activesupport (~> 5.2)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-ec2 (~> 1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    capistrano-asg (0.11.0.pre.pre)
+    capistrano-asg (0.11.0)
       activesupport (~> 5.2)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-ec2 (~> 1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    capistrano-asg (0.11.0-pre)
+    capistrano-asg (0.11.0)
       activesupport (~> 5.2)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-ec2 (~> 1)

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -54,23 +54,30 @@ def autoscale(groupname, roles: [], partial_roles: [], **args)
   end
 
   roles << "autoscale"
-  asg_instances.each do |asg_instance|
-    if asg_instance.health_status != "Healthy"
+
+  # Collect all instance ids from healthy instances
+  instance_ids = asg_instances.collect.each do |asg_instance|
+    unless asg_instance.health_status == "Healthy"
       puts "Autoscaling: Skipping unhealthy instance #{asg_instance.id}"
-    elsif asg_instance.lifecycle_state != "InService"
-      puts "Autoscaling: Skipping #{asg_instance.id}, lifecycle state is #{asg_instance.lifecycle_state}"
-    else
-      with_retry do
-        ec2_instance = ec2_resource.instance(asg_instance.id)
-        hostname = ec2_instance.private_ip_address
-        puts "Autoscaling: Adding server #{hostname}"
-        host_roles = roles.dup
-        if (additional_role = partial_queue.shift)
-          host_roles << additional_role
-        end
-        server(hostname, roles: host_roles, **args)
-      end
+      next
     end
+    unless asg_instance.lifecycle_state == "InService"
+      puts "Autoscaling: Skipping #{asg_instance.id}, lifecycle state is #{asg_instance.lifecycle_state}"
+      next
+    end
+
+    asg_instance.instance_id
+  end
+
+  # Pull all instances with enumerator to avoid hitting rate limiting for querying private IP
+  ec2_resource.instances(instance_ids: instance_ids.compact).each do |instance|
+    hostname = instance.private_ip_address
+    puts "Autoscaling: Adding server #{hostname}"
+    host_roles = roles.dup
+    if (additional_role = partial_queue.shift)
+      host_roles << additional_role
+    end
+    server(hostname, roles: host_roles, **args)
   end
 
   puts "WARNING: Not all partial roles were assigned: #{partial_queue}" unless partial_queue.empty?

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -57,9 +57,11 @@ def autoscale(groupname, roles: [], partial_roles: [], **args)
   roles << "autoscale"
 
   # Collect all instance ids from healthy instances
-  instance_ids = asg_instances.select do |asg_instance|
+  instance_ids = asg_instances.collect do |asg_instance|
     asg_instance.instance_id if healthy_instance?(asg_instance)
   end
+
+  instance_ids.compact!
 
   if instance_ids.empty?
     puts "Autoscaling group has no healthy instances"

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -57,15 +57,9 @@ def autoscale(groupname, roles: [], partial_roles: [], **args)
   roles << "autoscale"
 
   # Collect all instance ids from healthy instances
-  instance_ids = asg_instances.collect.each do |asg_instance|
-    if asg_instance.health_status != "Healthy" || asg_instance.lifecycle_state != "InService"
-      puts "Autoscaling: Skipping #{asg_instance.id}, status: #{asg_instance.health_status}, lifecycle: #{asg_instance.lifecycle_state}"
-      next
-    end
-
-    asg_instance.instance_id
+  instance_ids = asg_instances.select do |asg_instance|
+    asg_instance.instance_id if healthy_instance?(asg_instance)
   end
-  instance_ids.compact!
 
   if instance_ids.empty?
     puts "Autoscaling group has no healthy instances"
@@ -96,4 +90,12 @@ def autoscale(groupname, roles: [], partial_roles: [], **args)
 
   reset_autoscaling_objects
   reset_ec2_objects
+end
+
+def healthy_instance?(asg_instance)
+  if asg_instance.health_status != "Healthy" || asg_instance.lifecycle_state != "InService"
+    puts "Autoscaling: Skipping #{asg_instance.id}, status: #{asg_instance.health_status}, lifecycle: #{asg_instance.lifecycle_state}"
+    return false
+  end
+  true
 end

--- a/lib/capistrano/asg/version.rb
+++ b/lib/capistrano/asg/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Asg
-    VERSION = "0.11.0"
+    VERSION = "0.11.0-pre"
   end
 end

--- a/lib/capistrano/asg/version.rb
+++ b/lib/capistrano/asg/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Asg
-    VERSION = "0.10.0"
+    VERSION = "0.11.0-pre"
   end
 end

--- a/lib/capistrano/asg/version.rb
+++ b/lib/capistrano/asg/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Asg
-    VERSION = "0.11.0-pre"
+    VERSION = "0.11.0"
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176679215

Instead of rescue-ing lets just change the logic to pull all instance-ids at once (or iterate over multiple) to reduce the number of ec2 calls we make.  This pulls all instances based on the list of healthy instance-ids and iterates over that instead of iterating over each id and describing each instance separately.

New instance pending
```
$ aws-vault exec dox-dynamic -- cap dynamic deploy:check --trace ENV_NAME=qa-nroth-1
** Invoke dynamic (first_time)
** Execute dynamic
** Invoke load:defaults (first_time)
** Execute load:defaults
Autoscaling: Skipping i-0bf851eb44f77fc29, status: Healthy, lifecycle: Pending:Wait
Autoscaling group has no healthy instances
cap aborted!
Capistrano::Asg::NoHealthyInstances: Capistrano::Asg::NoHealthyInstances
```

New instance healthy
```
Autoscaling: Adding server 10.11.38.203
<snip>
** Execute git:wrapper
00:00 git:wrapper
      01 mkdir -p /tmp
```

Instance terminating
```
$ aws-vault exec dox-dynamic -- cap dynamic deploy:check --trace ENV_NAME=qa-nroth-1
** Invoke dynamic (first_time)
** Execute dynamic
** Invoke load:defaults (first_time)
** Execute load:defaults
Autoscaling: Skipping i-0bf851eb44f77fc29, status: Healthy, lifecycle: Terminating
Autoscaling group has no healthy instances
cap aborted!
Capistrano::Asg::NoHealthyInstances: Capistrano::Asg::NoHealthyInstances
```

